### PR TITLE
Fix API usage and login handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @K-Roon/homebridge-hejhome-IR
 
-현재 버전: **0.0.1** (Homebridge 플러그인 등록 완료)
+현재 버전: **0.0.2** (Homebridge 플러그인 등록 완료)
 
 한국어가 지원되는 Homebridge IR 서비스입니다. 아래 단계에 따라 Homebridge와 헤이홈(Hejhome)을 시작할 수 있는 기본 환경을 구축할 수 있습니다.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@K-Roon/homebridge-hejhome-IR",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@K-Roon/homebridge-hejhome-IR",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "homebridge-lib": "^7.1.4"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@K-Roon/homebridge-hejhome-IR",
   "displayName": "Hejhome IR",
   "type": "module",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": false,
   "description": "Homebridge plugin for Hejhome IR devices.",
   "author": "Hejhome Team",

--- a/src/accessories/IrAirconditionerAccessory.ts
+++ b/src/accessories/IrAirconditionerAccessory.ts
@@ -1,10 +1,17 @@
 import { CharacteristicValue, Service } from 'homebridge';
 import { IrBaseAccessory } from './IrBaseAccessory';
-import { HejhomeIRPlatform } from '../platform';
+import { HejhomeIRPlatform } from '../platform.js';
+import { HejhomeDevice, HejhomeApiClient } from '../api/GoqualClient.js';
+import type { PlatformAccessory } from 'homebridge';
 
 export class IrAirconditionerAccessory extends IrBaseAccessory {
-  constructor(...args: ConstructorParameters<typeof IrBaseAccessory>) {
-    super(...args, 'HeaterCooler');
+  constructor(
+    platform: HejhomeIRPlatform,
+    accessory: PlatformAccessory,
+    device: HejhomeDevice,
+    api: HejhomeApiClient,
+  ) {
+    super(platform, accessory, device, api, 'HeaterCooler');
 
     const { Characteristic } = this.platform.api.hap;
 
@@ -23,10 +30,10 @@ export class IrAirconditionerAccessory extends IrBaseAccessory {
 
   private async setActive(value: CharacteristicValue): Promise<void> {
     this.accessory.context.active = value;
-    await this.safeSend('power', value === 1 ? 'on' : 'off');
+    await this.fire('power');
   }
 
   private async setTargetTemp(value: CharacteristicValue): Promise<void> {
-    await this.safeSend('temperature', Number(value));
+    await this.fire(`temperature:${Number(value)}`);
   }
 }

--- a/src/accessories/IrBaseAccessory.ts
+++ b/src/accessories/IrBaseAccessory.ts
@@ -1,6 +1,6 @@
 import { Logger, PlatformAccessory, Service } from 'homebridge';
 import { HejhomeIRPlatform } from '../platform.js';
-import { HejhomeDevice, HejhomeApi } from '../hejhomeApi.js';
+import { HejhomeDevice, HejhomeApiClient } from '../api/GoqualClient.js';
 
 export abstract class IrBaseAccessory {
   protected readonly log: Logger;
@@ -10,7 +10,7 @@ export abstract class IrBaseAccessory {
     protected readonly platform: HejhomeIRPlatform,
     protected readonly accessory: PlatformAccessory,
     protected readonly device: HejhomeDevice,
-    protected readonly api: HejhomeApi,
+    protected readonly api: HejhomeApiClient,
     serviceType: string,
   ) {
     this.log = platform.log;
@@ -21,7 +21,7 @@ export abstract class IrBaseAccessory {
 
   protected async fire(cmd: string): Promise<void> {
     try {
-      await this.api.sendIr(this.device.id, cmd);
+      await this.api.sendIRCommand(this.device.id, cmd);
       this.log.debug(`${this.device.name} → ${cmd}`);
     } catch (e) {
       this.log.error('IR 전송 실패:', e);

--- a/src/accessories/IrFanAccessory.ts
+++ b/src/accessories/IrFanAccessory.ts
@@ -1,26 +1,33 @@
-import { CharacteristicValue } from 'homebridge';
+import { CharacteristicValue, PlatformAccessory } from 'homebridge';
 import { IrBaseAccessory } from './IrBaseAccessory.js';
+import { HejhomeIRPlatform } from '../platform.js';
+import { HejhomeDevice, HejhomeApiClient } from '../api/GoqualClient.js';
 
 export class IrFanAccessory extends IrBaseAccessory {
-  constructor(...args: ConstructorParameters<typeof IrBaseAccessory>) {
-    super(...args, 'Fan');
+  constructor(
+    platform: HejhomeIRPlatform,
+    accessory: PlatformAccessory,
+    device: HejhomeDevice,
+    api: HejhomeApiClient,
+  ) {
+    super(platform, accessory, device, api, 'Fan');
 
     const { Characteristic } = this.platform.api.hap;
 
     // 전원 (Active)
     this.service.getCharacteristic(Characteristic.Active)
-      .onSet(v => this.handlePower(v as number))
+      .onSet((v: CharacteristicValue) => this.handlePower(v as number))
       .onGet(() => 0);
 
     // 풍속 (RotationSpeed)
     this.service.getCharacteristic(Characteristic.RotationSpeed)
       .setProps({ minValue: 0, maxValue: 100, minStep: 1 })
-      .onSet(v => this.handleSpeed(v as number))
+      .onSet((v: CharacteristicValue) => this.handleSpeed(v as number))
       .onGet(() => 0);
 
     // 회전 (SwingMode)
     this.service.getCharacteristic(Characteristic.SwingMode)
-      .onSet(v => this.fire(v ? 'oscillate' : 'oscillate')) // 토글형 버튼
+      .onSet((v: CharacteristicValue) => this.fire(v ? 'oscillate' : 'oscillate')) // 토글형 버튼
       .onGet(() => 0);
   }
 
@@ -42,7 +49,7 @@ export class IrFanAccessory extends IrBaseAccessory {
     this.reset(this.platform.api.hap.Characteristic.RotationSpeed);
   }
 
-  private reset(char) {
+  private reset(char: any) {
     setTimeout(() => this.service.updateCharacteristic(char, 0), 500);
   }
 }

--- a/src/accessories/IrLampAccessory.ts
+++ b/src/accessories/IrLampAccessory.ts
@@ -1,9 +1,16 @@
-import { CharacteristicValue } from 'homebridge';
+import { CharacteristicValue, PlatformAccessory } from 'homebridge';
 import { IrBaseAccessory } from './IrBaseAccessory.js';
+import { HejhomeIRPlatform } from '../platform.js';
+import { HejhomeDevice, HejhomeApiClient } from '../api/GoqualClient.js';
 
 export class IrLampAccessory extends IrBaseAccessory {
-  constructor(...args: ConstructorParameters<typeof IrBaseAccessory>) {
-    super(...args, 'Lightbulb');
+  constructor(
+    platform: HejhomeIRPlatform,
+    accessory: PlatformAccessory,
+    device: HejhomeDevice,
+    api: HejhomeApiClient,
+  ) {
+    super(platform, accessory, device, api, 'Lightbulb');
 
     const { Characteristic } = this.platform.api.hap;
 
@@ -13,7 +20,7 @@ export class IrLampAccessory extends IrBaseAccessory {
 
     this.service.getCharacteristic(Characteristic.Brightness)
       .setProps({ minValue: 0, maxValue: 100, minStep: 100 }) // 0 또는 100
-      .onSet(v => this.toggle(v as number > 0))
+      .onSet((v: CharacteristicValue) => this.toggle(v as number > 0))
       .onGet(() => 0);
   }
 

--- a/src/accessories/IrStatelessSwitchAccessory.ts
+++ b/src/accessories/IrStatelessSwitchAccessory.ts
@@ -1,12 +1,17 @@
-import { CharacteristicValue } from 'homebridge';
+import { CharacteristicValue, PlatformAccessory } from 'homebridge';
 import { IrBaseAccessory } from './IrBaseAccessory.js';
+import { HejhomeIRPlatform } from '../platform.js';
+import { HejhomeDevice, HejhomeApiClient } from '../api/GoqualClient.js';
 
 export class IrStatelessSwitchAccessory extends IrBaseAccessory {
   constructor(
-    ...args: ConstructorParameters<typeof IrBaseAccessory>,
+    platform: HejhomeIRPlatform,
+    accessory: PlatformAccessory,
+    device: HejhomeDevice,
+    api: HejhomeApiClient,
     private readonly irCommand: string,
   ) {
-    super(...args, 'Switch');
+    super(platform, accessory, device, api, 'Switch');
     const { Characteristic } = this.platform.api.hap;
 
     this.service.getCharacteristic(Characteristic.On)
@@ -23,5 +28,4 @@ export class IrStatelessSwitchAccessory extends IrBaseAccessory {
           this.platform.api.hap.Characteristic.On, false);
       }, 500);
     }
-  }
-}
+  }}

--- a/src/accessories/IrTvAccessory.ts
+++ b/src/accessories/IrTvAccessory.ts
@@ -1,9 +1,16 @@
-import { CharacteristicValue } from 'homebridge';
+import { CharacteristicValue, PlatformAccessory } from 'homebridge';
 import { IrBaseAccessory } from './IrBaseAccessory.js';
+import { HejhomeIRPlatform } from '../platform.js';
+import { HejhomeDevice, HejhomeApiClient } from '../api/GoqualClient.js';
 
 export class IrTvAccessory extends IrBaseAccessory {
-  constructor(...args: ConstructorParameters<typeof IrBaseAccessory>) {
-    super(...args, 'Television');
+  constructor(
+    platform: HejhomeIRPlatform,
+    accessory: PlatformAccessory,
+    device: HejhomeDevice,
+    api: HejhomeApiClient,
+  ) {
+    super(platform, accessory, device, api, 'Television');
 
     const { Characteristic } = this.platform.api.hap;
 
@@ -16,7 +23,7 @@ export class IrTvAccessory extends IrBaseAccessory {
       this.platform.api.hap.Service.Switch, 'HDMI 1', 'hdmi1');
 
     hdmi1.getCharacteristic(Characteristic.On)
-      .onSet(async v => {
+      .onSet(async (v: CharacteristicValue) => {
         if (v) {
           await this.fire('hdmi1');
           setTimeout(() => hdmi1.updateCharacteristic(Characteristic.On, false), 500);


### PR DESCRIPTION
## Summary
- switch to GoqualClient API that needs only host, username, and password
- adjust all accessories to use new API client
- fix accessory handler typings and reset method

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: rimraf: not found)*
- `npx tsc` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686e5aecfa008331a33f28e9eb40bae7