### PR TITLE
Fix ESLint configuration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ export default [
   /* 1️⃣ ESLint 기본 JS 권장 규칙 */
   js.configs.recommended,
 
-  ...tseslint.configs.recommendedTypeChecked,
+  ...tseslint.configs.recommended,
 
   { ignores: ["dist/**", "node_modules/**"] },
 
@@ -16,11 +16,14 @@ export default [
     files: ["**/*.json"],
     ignores: ["package-lock.json"],
     plugins: { json },
-    languageOptions: { parser: json.parser },
-    rules: { "json/no-empty-keys": "warn" },
+    language: "json/json",
+    ...json.configs.recommended,
+    rules: { "json/no-empty-keys": "warn", "no-irregular-whitespace": "off" },
   },
 
   {
+    files: ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
+    plugins: { "@typescript-eslint": tseslint.plugin },
     rules: {
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],


### PR DESCRIPTION
## Summary
- update ESLint config to use the non-type-checked rules
- configure JSON linting properly
- set TypeScript rules only for TS files

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module 'homebridge' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686e6c29dd988331af4ad655c03a78a5