### PR TITLE
Rewrite Square OAuth helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # homebridge-hejhome-IR
 
-현재 버전: **0.0.6** (Homebridge 플러그인 등록 완료)
+현재 버전: **0.0.7** (Homebridge 플러그인 등록 완료)
 
 한국어가 지원되는 Homebridge IR 서비스입니다. 아래 단계에 따라 Homebridge와 헤이홈(Hejhome)을 시작할 수 있는 기본 환경을 구축할 수 있습니다.
 
@@ -14,6 +14,7 @@
 
 플러그인은 Homebridge UI에서 ID와 비밀번호를 입력할 수 있는 간단한 로그인 화면을 제공합니다.
 로그인 방식은 [homebridge-hejhome](https://github.com/chazepps/homebridge-hejhome) 프로젝트의 API 접근 예제를 참고했습니다.
+또한 Hej Square OAuth 흐름을 이용해 액세스 토큰을 자동으로 발급받습니다.
 또한 제어하려는 IR 기기 이름을 배열로 입력하면 해당 이름과 일치하는 장치만 Homebridge에 추가됩니다.
 
 ## 기본 환경 준비

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^8.36.0",
-        "homebridge-lib": "^7.1.4"
+        "homebridge-lib": "^7.1.4",
+        "validator": "^13.9.0"
       },
       "devDependencies": {
         "@eslint/css": "^0.9.0",
@@ -18,6 +19,7 @@
         "@eslint/json": "^0.12.0",
         "@eslint/markdown": "^6.6.0",
         "@types/node": "^22.13.5",
+        "@types/validator": "^13.7.11",
         "@typescript-eslint/parser": "^8.36.0",
         "eslint": "^9.30.1",
         "globals": "^16.3.0",
@@ -652,6 +654,13 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/validator": {
+      "version": "13.15.2",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.2.tgz",
+      "integrity": "sha512-y7pa/oEJJ4iGYBxOpfAKn5b9+xuihvzDVnC/OSvlVnGxVg0pOqmjiMafiJ1KVNQEaPZf9HsEp5icEwGg8uIe5Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -4878,6 +4887,15 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/validator": {
+      "version": "13.15.15",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
+      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^8.36.0",
-    "homebridge-lib": "^7.1.4"
+    "homebridge-lib": "^7.1.4",
+    "validator": "^13.9.0"
   },
   "devDependencies": {
     "@eslint/css": "^0.9.0",
@@ -54,6 +55,7 @@
     "rimraf": "^6.0.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.3",
-    "typescript-eslint": "^8.36.0"
+    "typescript-eslint": "^8.36.0",
+    "@types/validator": "^13.7.11"
   }
 }

--- a/src/api/squareToken.ts
+++ b/src/api/squareToken.ts
@@ -1,0 +1,110 @@
+import { Logger } from 'homebridge';
+import validator from 'validator';
+
+// These API credentials are referenced by other modules (e.g. realtime.ts). Do not
+// remove them, as MQTT authentication relies on their presence.
+export const HEJ_CLIENT_ID = 'e08a10573e37452daf2b948b390d5ef7';
+export const HEJ_CLIENT_SECRET = '097a8d169af04e48a33abb33b8788f12';
+
+/**
+ * Helper to build a Basic auth string.
+ */
+const encodeBasicAuth = (id: string, pw: string): string =>
+  `Basic ${Buffer.from(`${id}:${pw}`).toString('base64')}`;
+
+class SquareOAuthClient {
+  constructor(private readonly log: Logger) {}
+
+  private async fetchSession(auth: string): Promise<string | undefined> {
+    const resp = await fetch('https://square.hej.so/oauth/login?vendor=shop', {
+      method: 'POST',
+      headers: { authorization: auth },
+    });
+    const cookie = resp.headers.get('set-cookie');
+    return cookie?.match(/JSESSIONID=([^;]+)/)?.[1];
+  }
+
+  private async requestAuthCode(cookie: string): Promise<string | null> {
+    const url = new URL('https://square.hej.so/oauth/authorize');
+    url.searchParams.set('client_id', HEJ_CLIENT_ID);
+    url.searchParams.set('redirect_uri', 'https://square.hej.so/list');
+    url.searchParams.set('response_type', 'code');
+    url.searchParams.set('scope', 'shop');
+
+    const res = await fetch(url.toString(), {
+      headers: { cookie },
+      redirect: 'manual',
+    });
+
+    const location = res.headers.get('location');
+    return location ? location.match(/code=([^&]+)/)?.[1] ?? null : null;
+  }
+
+  private async exchangeToken(code: string): Promise<string> {
+    const form = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      client_id: HEJ_CLIENT_ID,
+      redirect_uri: 'https://square.hej.so/list',
+    });
+
+    const resp = await fetch('https://square.hej.so/oauth/token', {
+      method: 'POST',
+      headers: {
+        authorization: encodeBasicAuth(HEJ_CLIENT_ID, HEJ_CLIENT_SECRET),
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: form.toString(),
+      referrer: `https://square.hej.so/list?code=${code}`,
+      referrerPolicy: 'strict-origin-when-cross-origin',
+      credentials: 'include',
+      mode: 'cors',
+    });
+
+    const { access_token } = await resp.json() as { access_token: string };
+    return access_token;
+  }
+
+  async fetchToken(email?: string, password?: string): Promise<string | undefined> {
+    if (!email || !password) {
+      this.log.error('Email and password are required');
+      return;
+    }
+
+    if (!validator.isEmail(email)) {
+      this.log.error('Invalid email address');
+      return;
+    }
+
+    if (password.length < 4) {
+      this.log.error('Password must be at least 4 characters');
+      return;
+    }
+
+    const auth = encodeBasicAuth(email, password);
+    const session = await this.fetchSession(auth);
+    if (!session) {
+      this.log.error('Failed to start OAuth session');
+      return;
+    }
+
+    const cookie = `username=${encodeURIComponent(email)}; JSESSIONID=${session}`;
+    const code = await this.requestAuthCode(cookie);
+    if (!code) {
+      this.log.error('Failed to obtain authorization code');
+      return;
+    }
+
+    return this.exchangeToken(code);
+  }
+}
+
+export const obtainSquareToken = async (
+  log: Logger,
+  email?: string,
+  password?: string,
+): Promise<string | undefined> => {
+  const client = new SquareOAuthClient(log);
+  return client.fetchToken(email, password);
+};
+

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -35,12 +35,10 @@ export class HejhomeIRPlatform implements DynamicPlatformPlugin {
     const userId = config.username;
     const userPassword = config.password;
 
-    const API_CLIENT_ID = 'e08a10573e37452daf2b948b390d5ef7';
-    const API_CLIENT_SECRET = '097a8d169af04e48a33abb33b8788f12';
 
     this.api.on('didFinishLaunching', async () => {
       try {
-        await this.apiClient.getToken(API_CLIENT_ID, API_CLIENT_SECRET, userId, userPassword);
+        await this.apiClient.getTokenFromSquare(this.log, userId, userPassword);
         await this.apiClient.login(userId, userPassword);
         const devices = await this.apiClient.getIRDevices();
         const supported = devices.filter(d =>


### PR DESCRIPTION
## Summary
- rework square token retrieval into a small class
- update Goqual client to use the new helper
- document OAuth token flow in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686f8741945c833197a2984c264875d7