### PR TITLE
Fix OAuth token retrieval

### DIFF
--- a/src/api/squareToken.ts
+++ b/src/api/squareToken.ts
@@ -30,14 +30,18 @@ class SquareOAuthClient {
     url.searchParams.set('redirect_uri', 'https://square.hej.so/list');
     url.searchParams.set('response_type', 'code');
     url.searchParams.set('scope', 'shop');
+    url.searchParams.set('vendor', 'shop');
 
     const res = await fetch(url.toString(), {
       headers: { cookie },
       redirect: 'manual',
     });
-
     const location = res.headers.get('location');
-    return location ? location.match(/code=([^&]+)/)?.[1] ?? null : null;
+    if (!location) {
+      this.log.error(`Authorize request failed with status ${res.status}`);
+      return null;
+    }
+    return location.match(/code=([^&]+)/)?.[1] ?? null;
   }
 
   private async exchangeToken(code: string): Promise<string> {


### PR DESCRIPTION
## Summary
- add `vendor=shop` query parameter for Square OAuth
- log status code if the auth redirect is missing

## Testing
- `npm install`
- `npm run lint:ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686fa8dba5d08331941fba197504d468