### PR TITLE
Improve API request logging

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -29,7 +29,7 @@ export class HejhomeIRPlatform implements DynamicPlatformPlugin {
     public readonly config: PlatformConfig,
     public readonly api: API,
   ) {
-    this.apiClient = new HejhomeApiClient(config.host);
+    this.apiClient = new HejhomeApiClient(config.host, this.log);
 
     // Credentials from the Homebridge UI
     const userId = config.username;


### PR DESCRIPTION
## Summary
- add platform logger to API client
- log URLs for login, token retrieval, and generic requests

## Testing
- `npm run lint:ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870ce3beefc8331a19f7053b94eafa2