### PR TITLE
Fix credentials handling in docs and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # homebridge-hejhome-IR
 
-현재 버전: **1.0.0** (Homebridge 플러그인 등록 완료)
+현재 버전: **1.0.1** (Homebridge 플러그인 등록 완료)
 
 한국어가 지원되는 Homebridge IR 서비스입니다. 아래 단계에 따라 Homebridge와 헤이홈(Hejhome)을 시작할 수 있는 기본 환경을 구축할 수 있습니다.
 
@@ -44,13 +44,15 @@
          "platform": "HejhomeIR",
          "name": "Hejhome IR",
          "host": "http://localhost:8080",
-         "username": "YOUR_ID",
-          "password": "YOUR_PASSWORD",
-          "deviceNames": ["TARGET_DEVICE_1", "TARGET_DEVICE_2"]
+         "credentials": {
+           "email": "YOUR_ID",
+           "password": "YOUR_PASSWORD"
+         },
+         "deviceNames": ["TARGET_DEVICE_1", "TARGET_DEVICE_2"]
       }
     ]
   }
-``` ```
+```
 5. **Homebridge 실행**
    ```bash
    homebridge

--- a/config.schema.json
+++ b/config.schema.json
@@ -18,18 +18,25 @@
         "required": true,
         "default": "https://square.hej.so"
       },
-      "username": {
-        "title": "Hejhome 사용자 이름",
-        "type": "string",
-        "required": true
-      },
-      "password": {
-        "title": "Hejhome 비밀번호",
-        "type": "string",
+      "credentials": {
+        "title": "Hejhome 로그인 정보",
+        "type": "object",
         "required": true,
-        "format": "password",
-        "x-schema-form": {
-          "type": "password"
+        "properties": {
+          "email": {
+            "title": "Hejhome 이메일",
+            "type": "string",
+            "required": true
+          },
+          "password": {
+            "title": "Hejhome 비밀번호",
+            "type": "string",
+            "required": true,
+            "format": "password",
+            "x-schema-form": {
+              "type": "password"
+            }
+          }
         }
       },
       "deviceNames": {

--- a/src/api/get_token.ts
+++ b/src/api/get_token.ts
@@ -95,7 +95,9 @@ const getTokenResponse = async (code: string): Promise<Response> => {
 export const getToken = async (
   platform: HejhomePlatform,
 ): Promise<string | undefined> => {
-  const { email, password } = platform.config.credentials || {};
+  const email = platform.config.credentials?.email ?? platform.config.username;
+  const password =
+    platform.config.credentials?.password ?? platform.config.password;
 
   if (!email || !password) {
     platform.log.error('Email and password are required');

--- a/src/api/realtime.ts
+++ b/src/api/realtime.ts
@@ -282,7 +282,11 @@ export const startRealtime = async (platform: HejhomePlatform) => {
     password: HEJ_CLIENT_SECRET,
     useSSL: false,
     onSuccess: () => {
-      const email = platform.config.credentials?.email.replace(/\./gi, '-').replace(/%40/gi, '@');
+      const rawEmail =
+        platform.config.credentials?.email ?? platform.config.username;
+      const email = rawEmail
+        ?.replace(/\./gi, '-')
+        .replace(/%40/gi, '@');
       client.subscribe(`custom.${email}.*`, {
         qos: 1,
         timeout: 10,


### PR DESCRIPTION
## Summary
- update README with new `credentials` structure
- update config schema for nested credentials
- accept legacy `username`/`password` in code

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68724907608083318ee4aeadb1fa919d